### PR TITLE
feat: ポケモン検索機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,18 +41,19 @@ const generationBoundaries = [
 ];
 
 // Display Pokemon in grid
-function displayPokemon() {
+function displayPokemon(filteredData = null) {
     const grid = document.getElementById('pokemon-grid');
     grid.innerHTML = '';
     
     let currentGen = 1;
+    const dataToDisplay = filteredData || pokemonData;
     
-    pokemonData.forEach((pokemon, index) => {
+    dataToDisplay.forEach((pokemon, index) => {
         const pokemonId = parseInt(pokemon.ID);
         
         // Check if we need to add a generation separator
         const genBoundary = generationBoundaries.find(g => g.start === pokemonId);
-        if (genBoundary) {
+        if (genBoundary && !filteredData) {
             const separator = document.createElement('div');
             separator.className = 'generation-separator';
             separator.innerHTML = `<span>Generation ${genBoundary.gen} - ${genBoundary.name}</span>`;
@@ -61,7 +62,7 @@ function displayPokemon() {
         }
         
         const card = createPokemonCard(pokemon);
-        card.setAttribute('data-index', index);
+        card.setAttribute('data-index', filteredData ? pokemonData.indexOf(pokemon) : index);
         card.setAttribute('data-generation', currentGen);
         grid.appendChild(card);
     });
@@ -429,5 +430,38 @@ function initializeMinimap() {
     updateViewport();
 }
 
+// Search functionality
+function searchPokemon() {
+    const searchInput = document.getElementById('search-input');
+    const searchTerm = searchInput.value.toLowerCase().trim();
+    
+    if (searchTerm === '') {
+        displayPokemon();
+        return;
+    }
+    
+    const filteredPokemon = pokemonData.filter(pokemon => {
+        return pokemon.Name.toLowerCase().includes(searchTerm) ||
+               pokemon.Type1.toLowerCase().includes(searchTerm) ||
+               (pokemon.Type2 && pokemon.Type2.toLowerCase().includes(searchTerm)) ||
+               pokemon.ID.toString().includes(searchTerm);
+    });
+    
+    displayPokemon(filteredPokemon);
+}
+
 // Initialize when page loads
-document.addEventListener('DOMContentLoaded', loadPokemonData);
+document.addEventListener('DOMContentLoaded', () => {
+    loadPokemonData();
+    
+    // Setup search event listeners
+    const searchButton = document.getElementById('search-button');
+    const searchInput = document.getElementById('search-input');
+    
+    searchButton.addEventListener('click', searchPokemon);
+    searchInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            searchPokemon();
+        }
+    });
+});

--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
             </h1>
             <div class="pokeball-decoration"></div>
         </div>
+        <div class="search-container">
+            <input type="text" id="search-input" class="search-input" placeholder="ポケモンを検索...">
+            <button id="search-button" class="search-button">検索</button>
+        </div>
     </header>
     <div class="container">
         <div id="pokemon-grid" class="pokemon-grid"></div>

--- a/style.css
+++ b/style.css
@@ -67,6 +67,48 @@ body {
     opacity: 0.1;
 }
 
+/* Search container */
+.search-container {
+    max-width: 600px;
+    margin: 20px auto 0;
+    display: flex;
+    gap: 10px;
+    padding: 0 20px;
+}
+
+.search-input {
+    flex: 1;
+    padding: 12px 20px;
+    font-size: 16px;
+    border: 2px solid #ddd;
+    border-radius: 25px;
+    outline: none;
+    transition: border-color 0.3s;
+}
+
+.search-input:focus {
+    border-color: #ffcb05;
+}
+
+.search-button {
+    padding: 12px 30px;
+    font-size: 16px;
+    font-weight: 700;
+    background-color: #ffcb05;
+    color: #222;
+    border: 2px solid #222;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s;
+    text-transform: uppercase;
+}
+
+.search-button:hover {
+    background-color: #f7c005;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
 .pokeball-decoration::after {
     content: '';
     position: absolute;


### PR DESCRIPTION
## 概要
ポケモンブラウザーに検索機能を追加しました。

## 変更内容
- ヘッダーに検索ボックスと検索ボタンを追加
- 以下の条件でポケモンを検索可能：
  - ポケモン名（部分一致）
  - タイプ（Type1、Type2）
  - ID番号
- Enterキーでも検索を実行できるように実装
- ポケモンブランドに合わせた黄色のスタイリングを適用

## スクリーンショット
検索ボックスはヘッダーのタイトル下に配置され、黄色のボタンでポケモンらしいデザインになっています。