### PR TITLE
feat: ポケモン検索機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 let pokemonData = [];
+let filteredPokemonData = [];
 
 // Load Pokemon data
 async function loadPokemonData() {
@@ -6,7 +7,9 @@ async function loadPokemonData() {
         const response = await fetch('pokemon_data.csv');
         const csvText = await response.text();
         pokemonData = parseCSV(csvText);
+        filteredPokemonData = [...pokemonData];
         displayPokemon();
+        initializeSearch();
     } catch (error) {
         console.error('Error loading Pokemon data:', error);
     }
@@ -47,7 +50,7 @@ function displayPokemon() {
     
     let currentGen = 1;
     
-    pokemonData.forEach((pokemon, index) => {
+    filteredPokemonData.forEach((pokemon, index) => {
         const pokemonId = parseInt(pokemon.ID);
         
         // Check if we need to add a generation separator
@@ -61,7 +64,8 @@ function displayPokemon() {
         }
         
         const card = createPokemonCard(pokemon);
-        card.setAttribute('data-index', index);
+        const originalIndex = pokemonData.findIndex(p => p.ID === pokemon.ID && p.Name === pokemon.Name && p.Form === pokemon.Form);
+        card.setAttribute('data-index', originalIndex);
         card.setAttribute('data-generation', currentGen);
         grid.appendChild(card);
     });
@@ -430,4 +434,50 @@ function initializeMinimap() {
 }
 
 // Initialize when page loads
+// Initialize search functionality
+function initializeSearch() {
+    const searchInput = document.getElementById('search-input');
+    const searchButton = document.getElementById('search-button');
+    const clearButton = document.getElementById('clear-button');
+    
+    // Search function
+    function performSearch() {
+        const searchTerm = searchInput.value.trim().toLowerCase();
+        
+        if (searchTerm === '') {
+            filteredPokemonData = [...pokemonData];
+        } else {
+            filteredPokemonData = pokemonData.filter(pokemon => {
+                // 名前、タイプ、フォームで検索
+                const nameMatch = pokemon.Name.toLowerCase().includes(searchTerm);
+                const type1Match = pokemon.Type1.toLowerCase().includes(searchTerm);
+                const type2Match = pokemon.Type2 && pokemon.Type2.toLowerCase().includes(searchTerm);
+                const formMatch = pokemon.Form && pokemon.Form.toLowerCase().includes(searchTerm);
+                
+                return nameMatch || type1Match || type2Match || formMatch;
+            });
+        }
+        
+        displayPokemon();
+    }
+    
+    // Clear search
+    function clearSearch() {
+        searchInput.value = '';
+        filteredPokemonData = [...pokemonData];
+        displayPokemon();
+    }
+    
+    // Event listeners
+    searchButton.addEventListener('click', performSearch);
+    clearButton.addEventListener('click', clearSearch);
+    
+    // Enterキーでも検索可能に
+    searchInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            performSearch();
+        }
+    });
+}
+
 document.addEventListener('DOMContentLoaded', loadPokemonData);

--- a/index.html
+++ b/index.html
@@ -17,6 +17,11 @@
         </div>
     </header>
     <div class="container">
+        <div class="search-container">
+            <input type="text" id="search-input" class="search-input" placeholder="ポケモンを検索..." />
+            <button id="search-button" class="search-button">検索</button>
+            <button id="clear-button" class="clear-button">クリア</button>
+        </div>
         <div id="pokemon-grid" class="pokemon-grid"></div>
         <div id="pokemon-detail" class="pokemon-detail hidden"></div>
     </div>

--- a/style.css
+++ b/style.css
@@ -87,6 +87,72 @@ body {
     padding: 30px 20px 20px;
 }
 
+/* 検索コンテナスタイル */
+.search-container {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 30px;
+    align-items: center;
+    justify-content: center;
+}
+
+.search-input {
+    width: 100%;
+    max-width: 400px;
+    padding: 12px 20px;
+    font-size: 16px;
+    border: 2px solid #ddd;
+    border-radius: 25px;
+    outline: none;
+    transition: border-color 0.3s;
+}
+
+.search-input:focus {
+    border-color: #3498db;
+}
+
+.search-button {
+    padding: 12px 30px;
+    font-size: 16px;
+    font-weight: 600;
+    background-color: #3498db;
+    color: white;
+    border: none;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.1s;
+}
+
+.search-button:hover {
+    background-color: #2980b9;
+    transform: translateY(-1px);
+}
+
+.search-button:active {
+    transform: translateY(0);
+}
+
+.clear-button {
+    padding: 12px 20px;
+    font-size: 16px;
+    font-weight: 600;
+    background-color: #e74c3c;
+    color: white;
+    border: none;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.1s;
+}
+
+.clear-button:hover {
+    background-color: #c0392b;
+    transform: translateY(-1px);
+}
+
+.clear-button:active {
+    transform: translateY(0);
+}
+
 .pokemon-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));


### PR DESCRIPTION
## 概要
ポケモンブラウザに検索機能を追加しました。

## 変更内容
- 検索ボックス、検索ボタン、クリアボタンをヘッダー下に追加
- ポケモンの名前、タイプ1、タイプ2、フォームで検索可能
- Enterキーでも検索を実行できます
- 検索結果はリアルタイムで表示されます

## 使い方
1. 検索ボックスにポケモン名やタイプを入力
2. 「検索」ボタンをクリックするか、Enterキーを押す
3. 「クリア」ボタンで検索をリセット

## スクリーンショット
検索機能が追加されたUIをご確認ください。