### PR TITLE
ポケモン名の検索機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -429,5 +429,68 @@ function initializeMinimap() {
     updateViewport();
 }
 
+// Search functionality
+function initializeSearch() {
+    const searchInput = document.getElementById('search-input');
+    const searchButton = document.getElementById('search-button');
+    const clearButton = document.getElementById('clear-button');
+    
+    function performSearch() {
+        const searchTerm = searchInput.value.toLowerCase().trim();
+        
+        if (searchTerm === '') {
+            displayPokemon();
+            return;
+        }
+        
+        const filteredPokemon = pokemonData.filter(pokemon => {
+            const name = pokemon.Name.toLowerCase();
+            return name.includes(searchTerm);
+        });
+        
+        displayFilteredPokemon(filteredPokemon);
+    }
+    
+    function clearSearch() {
+        searchInput.value = '';
+        displayPokemon();
+    }
+    
+    // Event listeners
+    searchButton.addEventListener('click', performSearch);
+    clearButton.addEventListener('click', clearSearch);
+    
+    // Search on Enter key
+    searchInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            performSearch();
+        }
+    });
+}
+
+// Display filtered Pokemon
+function displayFilteredPokemon(filteredPokemon) {
+    const grid = document.getElementById('pokemon-grid');
+    grid.innerHTML = '';
+    
+    if (filteredPokemon.length === 0) {
+        grid.innerHTML = '<div class="no-results">ポケモンが見つかりませんでした</div>';
+        return;
+    }
+    
+    filteredPokemon.forEach((pokemon, index) => {
+        const card = createPokemonCard(pokemon);
+        const originalIndex = pokemonData.findIndex(p => p.ID === pokemon.ID);
+        card.setAttribute('data-index', originalIndex);
+        grid.appendChild(card);
+    });
+    
+    // Update minimap after filtering
+    initializeMinimap();
+}
+
 // Initialize when page loads
-document.addEventListener('DOMContentLoaded', loadPokemonData);
+document.addEventListener('DOMContentLoaded', () => {
+    loadPokemonData();
+    initializeSearch();
+});

--- a/index.html
+++ b/index.html
@@ -17,6 +17,11 @@
         </div>
     </header>
     <div class="container">
+        <div class="search-container">
+            <input type="text" id="search-input" class="search-input" placeholder="ポケモンを検索...">
+            <button id="search-button" class="search-button">検索</button>
+            <button id="clear-button" class="clear-button">クリア</button>
+        </div>
         <div id="pokemon-grid" class="pokemon-grid"></div>
         <div id="pokemon-detail" class="pokemon-detail hidden"></div>
     </div>

--- a/style.css
+++ b/style.css
@@ -87,6 +87,72 @@ body {
     padding: 30px 20px 20px;
 }
 
+/* Search Container */
+.search-container {
+    position: sticky;
+    top: 80px;
+    display: flex;
+    gap: 10px;
+    background-color: rgba(255, 255, 255, 0.98);
+    padding: 15px;
+    border-radius: 15px;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    margin-bottom: 30px;
+}
+
+.search-input {
+    flex: 1;
+    padding: 12px 20px;
+    border: 2px solid var(--pokemon-red);
+    border-radius: 25px;
+    font-size: 16px;
+    font-family: inherit;
+    outline: none;
+    transition: all 0.3s ease;
+}
+
+.search-input:focus {
+    border-color: var(--pokemon-yellow);
+    box-shadow: 0 0 0 3px rgba(255, 203, 5, 0.2);
+}
+
+.search-button,
+.clear-button {
+    padding: 12px 25px;
+    border: none;
+    border-radius: 25px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-family: inherit;
+}
+
+.search-button {
+    background-color: var(--pokemon-yellow);
+    color: #333;
+    border: 2px solid var(--pokemon-yellow);
+    font-weight: 700;
+}
+
+.search-button:hover {
+    background-color: #F0B800;
+    border-color: #F0B800;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(255, 203, 5, 0.4);
+}
+
+.clear-button {
+    background-color: #E0E0E0;
+    color: #333;
+}
+
+.clear-button:hover {
+    background-color: #BDBDBD;
+    transform: translateY(-2px);
+}
+
 .pokemon-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -100,6 +166,16 @@ body {
     padding: 20px 0;
     margin: 20px 0;
     position: relative;
+}
+
+/* No results message */
+.no-results {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 60px 20px;
+    font-size: 20px;
+    color: #666;
+    font-weight: 500;
 }
 
 .generation-separator span {


### PR DESCRIPTION
## 変更内容
- 検索ボックスと検索・クリアボタンを追加
- ポケモン名での検索機能を実装
- 検索UIのスタイリングを追加（ヘッダーと同じ黄色のボタン）

## 機能
- ポケモン名を入力して検索できます
- 「検索」ボタンまたはEnterキーで検索実行
- 「クリア」ボタンで検索をリセット
- 検索結果がない場合は「ポケモンが見つかりませんでした」と表示