### PR TITLE
feat: ポケモン名での検索機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,11 @@
             </h1>
             <div class="pokeball-decoration"></div>
         </div>
+        <div class="search-container">
+            <input type="text" id="search-input" class="search-input" placeholder="ポケモンの名前を入力...">
+            <button id="search-button" class="search-button">検索</button>
+            <button id="clear-button" class="clear-button">クリア</button>
+        </div>
     </header>
     <div class="container">
         <div id="pokemon-grid" class="pokemon-grid"></div>
@@ -24,7 +29,7 @@
         <div class="minimap-viewport"></div>
         <canvas id="minimap-canvas"></canvas>
     </div>
-    <script src="similarity.js?v=2"></script>
-    <script src="app.js?v=2"></script>
+    <script src="similarity.js?v=3"></script>
+    <script src="app.js?v=3"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -80,11 +80,86 @@ body {
     border-radius: 50%;
 }
 
+/* Search container styles */
+.search-container {
+    max-width: 600px;
+    margin: 20px auto 0;
+    padding: 0 20px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.search-input {
+    flex: 1;
+    padding: 10px 15px;
+    font-size: 16px;
+    border: 2px solid #ddd;
+    border-radius: 25px;
+    outline: none;
+    transition: border-color 0.3s;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.search-input:focus {
+    border-color: #ffcb05;
+}
+
+.search-input::placeholder {
+    color: #999;
+}
+
+.search-button, .clear-button {
+    padding: 10px 20px;
+    font-size: 16px;
+    font-weight: bold;
+    border: none;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.search-button {
+    background: #ffcb05;
+    color: #222;
+    border: 2px solid #222;
+}
+
+.search-button:hover {
+    background: #ffd733;
+    transform: scale(1.05);
+}
+
+.clear-button {
+    background: #f0f0f0;
+    color: #666;
+    border: 2px solid #ddd;
+}
+
+.clear-button:hover {
+    background: #e0e0e0;
+    border-color: #bbb;
+}
+
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 30px 20px 20px;
+}
+
+/* No results message */
+.no-results {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 60px 20px;
+    color: #666;
+    font-size: 18px;
+}
+
+.no-results p:first-child {
+    font-weight: bold;
+    margin-bottom: 10px;
 }
 
 .pokemon-grid {


### PR DESCRIPTION
## 概要
ポケモンブラウザに検索機能を追加しました。ポケモンの名前で検索できるようになります。

## 変更内容
- ヘッダーに検索ボックスと検索/クリアボタンを追加
- 名前（フォーム名含む）での部分一致検索を実装  
- 検索結果が0件の場合のメッセージ表示を追加
- Enterキーでの検索実行に対応
- 検索時は世代区切りを非表示に

## 使い方
1. 検索ボックスにポケモン名を入力
2. 「検索」ボタンをクリックまたはEnterキーを押す
3. 「クリア」ボタンで検索をリセット